### PR TITLE
Fix object size handling in S3 collector

### DIFF
--- a/pkg/s3collector.go
+++ b/pkg/s3collector.go
@@ -299,11 +299,8 @@ func getBucketStorageMetrics(ctx context.Context, client *s3.Client, bucketName 
 				storageClass = "STANDARD" // Default storage class
 			}
 
-			// Add size to totals - handle pointer properly
-			objSize := int64(0)
-			if obj.Size != nil {
-				objSize = *obj.Size
-			}
+			// Add size to totals
+			objSize := obj.Size
 
 			size += objSize
 			storageClasses[storageClass] += objSize


### PR DESCRIPTION
## Summary
- fix incorrect pointer check for S3 object size

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68401944df808325a151f701a76038ba